### PR TITLE
Feature/762 optimize dockerfiles

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,7 +6,7 @@ defaults_working_directory: &defaults_working_directory
 
 defaults_docker_node: &defaults_docker_node
   docker:
-    - image: mhart/alpine-node:10.15.1
+    - image: node:10.15.3-alpine
 
 defaults_docker_helm_kube: &defaults_docker_helm_kube
   docker:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,18 +1,22 @@
-FROM node:10.15-alpine
+FROM node:10.15.3-alpine
 
 WORKDIR /opt/account-lookup-service
-COPY . /opt/account-lookup-service
 
 RUN apk add --no-cache -t build-dependencies git make gcc g++ python libtool autoconf automake \
     && cd $(npm root -g)/npm \
     && npm config set unsafe-perm true \
     && npm install -g node-gyp
 
+COPY package.json package-lock.json* /opt/account-lookup-service/
 RUN npm install --production
 
 RUN apk del build-dependencies
 
+COPY config /opt/account-lookup-service/config
+COPY migrations /opt/account-lookup-service/migrations
+COPY seeds /opt/account-lookup-service/seeds
+COPY src /opt/account-lookup-service/src
+
 EXPOSE 4002
 EXPOSE 4001
-
-CMD npm run start
+CMD ["npm", "run", "start"]

--- a/admin.Dockerfile
+++ b/admin.Dockerfile
@@ -1,17 +1,21 @@
-FROM node:10.15-alpine
+FROM node:10.15.3-alpine
 
 WORKDIR /opt/account-lookup-service
-COPY . /opt/account-lookup-service
 
 RUN apk add --no-cache -t build-dependencies git make gcc g++ python libtool autoconf automake \
     && cd $(npm root -g)/npm \
     && npm config set unsafe-perm true \
     && npm install -g node-gyp
 
-RUN npm install --production && \
-  npm uninstall -g npm
+COPY package.json package-lock.json* /opt/account-lookup-service/
+RUN npm install --production
 
 RUN apk del build-dependencies
 
+COPY config /opt/account-lookup-service/config
+COPY migrations /opt/account-lookup-service/migrations
+COPY seeds /opt/account-lookup-service/seeds
+COPY src /opt/account-lookup-service/src
+
 EXPOSE 4002
-CMD npm run start:admin
+CMD ["npm", "run", "start:admin"]

--- a/api.Dockerfile
+++ b/api.Dockerfile
@@ -1,17 +1,21 @@
-FROM node:10.15-alpine
+FROM node:10.15.3-alpine
 
 WORKDIR /opt/account-lookup-service
-COPY . /opt/account-lookup-service
 
 RUN apk add --no-cache -t build-dependencies git make gcc g++ python libtool autoconf automake \
     && cd $(npm root -g)/npm \
     && npm config set unsafe-perm true \
     && npm install -g node-gyp
 
-RUN npm install --production && \
-  npm uninstall -g npm
+COPY package.json package-lock.json* /opt/account-lookup-service/
+RUN npm install --production
 
 RUN apk del build-dependencies
 
+COPY config /opt/account-lookup-service/config
+COPY migrations /opt/account-lookup-service/migrations
+COPY seeds /opt/account-lookup-service/seeds
+COPY src /opt/account-lookup-service/src
+
 EXPOSE 4001
-CMD npm run start:api
+CMD ["npm", "run", "start:api"]

--- a/package-lock.json
+++ b/package-lock.json
@@ -2529,8 +2529,7 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -2551,14 +2550,12 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -2573,20 +2570,17 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -2703,8 +2697,7 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "ini": {
           "version": "1.3.5",
@@ -2716,7 +2709,6 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -2731,7 +2723,6 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -2739,14 +2730,12 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "minipass": {
           "version": "2.3.5",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -2765,7 +2754,6 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -2846,8 +2834,7 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -2859,7 +2846,6 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -2945,8 +2931,7 @@
         "safe-buffer": {
           "version": "5.1.2",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -2982,7 +2967,6 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -3002,7 +2986,6 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -3046,14 +3029,12 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "yallist": {
           "version": "3.0.3",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -106,10 +106,10 @@
     "seed:run": "knex seed:run $npm_package_config_knex",
     "seed:create": "knex seed:make $npm_package_config_knex",
     "regenerate": "yo swaggerize:test --framework hapi --apiPath './config/api_swagger.json'",
-    "build": "docker build -t central-directory:local -f ../Dockerfile ../",
+    "build": "docker build -t central-directory:local -f ./Dockerfile .",
     "run": "docker run -p 3000:3000 --rm --link db:mysql central-directory:local",
     "package-lock": "docker run --rm -it central-directory:local cat package-lock.json > package-lock.json",
-    "generate-docs": "node_modules/.bin/jsdoc -c jsdoc.json"
+    "generate-docs": "jsdoc -c jsdoc.json"
   },
   "generator-swaggerize": {
     "version": "4.1.0"

--- a/package.json
+++ b/package.json
@@ -106,7 +106,9 @@
     "seed:run": "knex seed:run $npm_package_config_knex",
     "seed:create": "knex seed:make $npm_package_config_knex",
     "regenerate": "yo swaggerize:test --framework hapi --apiPath './config/api_swagger.json'",
-    "build": "docker build -t central-directory:local -f ./Dockerfile .",
+    "build": "docker build -t account-lookup-service:local -f ./Dockerfile .",
+    "build:api": "docker build -t account-lookup-service-api:local -f ./api.Dockerfile .",
+    "build:admin": "docker build -t account-lookup-service-admin:local -f ./admin.Dockerfile .",
     "run": "docker run -p 3000:3000 --rm --link db:mysql central-directory:local",
     "package-lock": "docker run --rm -it central-directory:local cat package-lock.json > package-lock.json",
     "generate-docs": "jsdoc -c jsdoc.json"


### PR DESCRIPTION
Part of https://github.com/mojaloop/project/issues/762

- Reordered and optimized the commands for `Dockerfile`, `api.Dockerfile` and `admin.Dockerfile` to take better advantage of docker layer caching.
- Interestingly enough, it doesn't look like the `api.Dockerfile` and `admin.Dockerfile`s are used anywhere. 
- Changed base image to official alpine image to `node:10.15.3-alpine`

All of these images build and test locally just fine.