### PR TITLE
ALS async error responses for Oracle responses

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "account-lookup-service",
-  "version": "7.5.1",
+  "version": "7.5.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -748,9 +748,9 @@
       }
     },
     "@mojaloop/central-services-error-handling": {
-      "version": "7.4.5",
-      "resolved": "https://registry.npmjs.org/@mojaloop/central-services-error-handling/-/central-services-error-handling-7.4.5.tgz",
-      "integrity": "sha512-iMUNv0EUumB8AQEwscf1RhNe2qUgMSNsA+4z3CqQW8WG8yBN3ZHrgkdzLC2sM8YMZQQRM4BtiIEydwl9Ac5YqQ==",
+      "version": "7.5.0",
+      "resolved": "https://registry.npmjs.org/@mojaloop/central-services-error-handling/-/central-services-error-handling-7.5.0.tgz",
+      "integrity": "sha512-Spjllgyx6Y7En5vj7LaRVM5aTU+uuEykawPQaYzj3ZXAQdyHO4Slns8/ggwQ65T2qyMv1PXiqLK5dPBcIRlWYg==",
       "requires": {
         "@mojaloop/sdk-standard-components": "7.4.0",
         "lodash": "4.17.15"
@@ -882,9 +882,9 @@
       }
     },
     "@mojaloop/central-services-shared": {
-      "version": "7.5.0",
-      "resolved": "https://registry.npmjs.org/@mojaloop/central-services-shared/-/central-services-shared-7.5.0.tgz",
-      "integrity": "sha512-RYB3PbnQBVPttqoYIsV7EOTQU9PEFwB7xzbMd3Xeq7+ls+ON32Tz4viA0VoPu81Gcgsuz11fnrzAiiBRBhB5YQ==",
+      "version": "7.5.2",
+      "resolved": "https://registry.npmjs.org/@mojaloop/central-services-shared/-/central-services-shared-7.5.2.tgz",
+      "integrity": "sha512-fRUNICV8K3zhTRDjlq6XvyctJscNrJkcYMSIOyp495F+mFO3DUwM1GTI7qFGDi4F3f8tiIpCyOQrTOKInJiwvg==",
       "requires": {
         "@mojaloop/central-services-error-handling": "7.4.0",
         "@mojaloop/central-services-stream": "6.2.2",
@@ -906,91 +906,8 @@
           "resolved": "https://registry.npmjs.org/@mojaloop/central-services-error-handling/-/central-services-error-handling-7.4.0.tgz",
           "integrity": "sha512-+2OhkP06q6aR23tqxelHwG/hzA+y10cbPBAC3ovlB0z/n1R90ENek0RKyNcDw0F9ComSmBFiY3k9gOrPYv0w8A==",
           "requires": {
-            "@mojaloop/central-services-shared": "7.4.4",
             "@mojaloop/sdk-standard-components": "7.4.0",
             "lodash": "4.17.15"
-          },
-          "dependencies": {
-            "@mojaloop/central-services-error-handling": {
-              "version": "7.3.0",
-              "resolved": "https://registry.npmjs.org/@mojaloop/central-services-error-handling/-/central-services-error-handling-7.3.0.tgz",
-              "integrity": "sha512-LSqQkI2/2BI7EukrWgOFafk1rBkxrwgNDfJ1NQ1ZqvsJ5/Xuapd2rJbRi2mik5bfjObU43+GBEzWBqIGnZpksQ==",
-              "requires": {
-                "@modusbox/mojaloop-sdk-standard-components": "0.0.37",
-                "@mojaloop/central-services-shared": "6.4.1",
-                "lodash": "4.17.15"
-              },
-              "dependencies": {
-                "@mojaloop/central-services-shared": {
-                  "version": "6.4.1",
-                  "resolved": "https://registry.npmjs.org/@mojaloop/central-services-shared/-/central-services-shared-6.4.1.tgz",
-                  "integrity": "sha512-ihtRxZiMghJgqXdstVi/qr0VepOfr2uA1VYfnPNB16TZoojWtG0xt538XG/3TfYJfxVOaShc+WlJBVoxUs774w==",
-                  "requires": {
-                    "async": "3.1.0",
-                    "debug": "4.1.1",
-                    "winston": "3.2.1"
-                  }
-                }
-              }
-            },
-            "@mojaloop/central-services-shared": {
-              "version": "7.4.4",
-              "resolved": "https://registry.npmjs.org/@mojaloop/central-services-shared/-/central-services-shared-7.4.4.tgz",
-              "integrity": "sha512-BB2iHjFuLbKyN2RUVRb5vPICfkAwJuf1uenCDvJdbl6b8/9ZB83uKyaia8BbIlhzVfv3rAFzH9Z5R3edllwvcw==",
-              "requires": {
-                "@mojaloop/central-services-error-handling": "7.3.0",
-                "@mojaloop/central-services-stream": "6.2.2",
-                "axios": "0.19.0",
-                "catbox": "10.0.6",
-                "catbox-memory": "4.0.1",
-                "glob": "7.1.4",
-                "immutable": "3.8.2",
-                "lodash": "4.17.15",
-                "mustache": "3.0.1",
-                "raw-body": "2.4.1",
-                "uuid4": "1.1.4",
-                "winston": "3.2.1"
-              },
-              "dependencies": {
-                "@mojaloop/central-services-error-handling": {
-                  "version": "7.3.0",
-                  "resolved": "https://registry.npmjs.org/@mojaloop/central-services-error-handling/-/central-services-error-handling-7.3.0.tgz",
-                  "integrity": "sha512-LSqQkI2/2BI7EukrWgOFafk1rBkxrwgNDfJ1NQ1ZqvsJ5/Xuapd2rJbRi2mik5bfjObU43+GBEzWBqIGnZpksQ==",
-                  "requires": {
-                    "@modusbox/mojaloop-sdk-standard-components": "0.0.37",
-                    "@mojaloop/central-services-shared": "6.4.1",
-                    "lodash": "4.17.15"
-                  },
-                  "dependencies": {
-                    "@mojaloop/central-services-shared": {
-                      "version": "6.4.1",
-                      "resolved": "https://registry.npmjs.org/@mojaloop/central-services-shared/-/central-services-shared-6.4.1.tgz",
-                      "integrity": "sha512-ihtRxZiMghJgqXdstVi/qr0VepOfr2uA1VYfnPNB16TZoojWtG0xt538XG/3TfYJfxVOaShc+WlJBVoxUs774w==",
-                      "requires": {
-                        "async": "3.1.0",
-                        "debug": "4.1.1",
-                        "winston": "3.2.1"
-                      }
-                    }
-                  }
-                },
-                "@mojaloop/central-services-shared": {
-                  "version": "6.4.1",
-                  "resolved": "https://registry.npmjs.org/@mojaloop/central-services-shared/-/central-services-shared-6.4.1.tgz",
-                  "integrity": "sha512-ihtRxZiMghJgqXdstVi/qr0VepOfr2uA1VYfnPNB16TZoojWtG0xt538XG/3TfYJfxVOaShc+WlJBVoxUs774w==",
-                  "requires": {
-                    "async": "3.1.0",
-                    "debug": "4.1.1",
-                    "winston": "3.2.1"
-                  }
-                }
-              }
-            },
-            "mustache": {
-              "version": "3.0.1",
-              "resolved": "https://registry.npmjs.org/mustache/-/mustache-3.0.1.tgz",
-              "integrity": "sha512-jFI/4UVRsRYdUbuDTKT7KzfOp7FiD5WzYmmwNwXyUVypC0xjoTL78Fqc0jHUPIvvGD+6DQSPHIt1NE7D1ArsqA=="
-            }
           }
         },
         "@mojaloop/central-services-shared": {
@@ -1166,7 +1083,20 @@
                   "integrity": "sha512-LSqQkI2/2BI7EukrWgOFafk1rBkxrwgNDfJ1NQ1ZqvsJ5/Xuapd2rJbRi2mik5bfjObU43+GBEzWBqIGnZpksQ==",
                   "requires": {
                     "@modusbox/mojaloop-sdk-standard-components": "0.0.37",
+                    "@mojaloop/central-services-shared": "6.4.1",
                     "lodash": "4.17.15"
+                  },
+                  "dependencies": {
+                    "@mojaloop/central-services-shared": {
+                      "version": "6.4.1",
+                      "resolved": "https://registry.npmjs.org/@mojaloop/central-services-shared/-/central-services-shared-6.4.1.tgz",
+                      "integrity": "sha512-ihtRxZiMghJgqXdstVi/qr0VepOfr2uA1VYfnPNB16TZoojWtG0xt538XG/3TfYJfxVOaShc+WlJBVoxUs774w==",
+                      "requires": {
+                        "async": "3.1.0",
+                        "debug": "4.1.1",
+                        "winston": "3.2.1"
+                      }
+                    }
                   }
                 },
                 "@mojaloop/central-services-shared": {
@@ -1301,6 +1231,7 @@
               "resolved": "https://registry.npmjs.org/@mojaloop/central-services-stream/-/central-services-stream-6.2.2.tgz",
               "integrity": "sha512-NsKMYRjNQdBJ1290xP1/Kjs1MKgtBINFs3CLcnhrWW1sMwdfLakAwoVdiaZmJMguk5sung7T5hbHWC/XNQOyoQ==",
               "requires": {
+                "@mojaloop/central-services-shared": "5.2.0",
                 "async": "2.6.2",
                 "base64url": "3.0.1",
                 "bluebird": "3.5.3",
@@ -1312,6 +1243,16 @@
                 "raw-body": "2.4.0"
               },
               "dependencies": {
+                "@mojaloop/central-services-shared": {
+                  "version": "5.2.0",
+                  "resolved": "https://registry.npmjs.org/@mojaloop/central-services-shared/-/central-services-shared-5.2.0.tgz",
+                  "integrity": "sha512-wcHlPdJKziJMqjDIbYp8WLXT5ZI/0ITdrxl2QHDK03geZ6UWJ0B6EnRe1LPKWM2M/bBzzybB9vHU8UI+/QwXgw==",
+                  "requires": {
+                    "async": "2.6.2",
+                    "debug": "4.1.1",
+                    "winston": "3.2.1"
+                  }
+                },
                 "http-errors": {
                   "version": "1.7.2",
                   "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.7.2.tgz",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "@mojaloop/central-services-error-handling": "7.5.0",
     "@mojaloop/central-services-health": "7.0.0",
     "@mojaloop/central-services-metrics": "5.2.0",
-    "@mojaloop/central-services-shared": "7.5.1",
+    "@mojaloop/central-services-shared": "7.5.2",
     "@mojaloop/central-services-stream": "7.4.2",
     "@now-ims/hapi-now-auth": "2.0.0",
     "blipp": "4.0.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "account-lookup-service",
   "description": "Account Lookup Service is used to validate Party and Participant lookups",
-  "version": "7.5.1",
+  "version": "7.5.2",
   "license": "Apache-2.0",
   "author": "ModusBox",
   "contributors": [
@@ -37,10 +37,10 @@
     "@hapi/inert": "5.2.1",
     "@hapi/vision": "5.5.3",
     "@mojaloop/central-services-database": "7.4.0",
-    "@mojaloop/central-services-error-handling": "7.4.5",
+    "@mojaloop/central-services-error-handling": "7.5.0",
     "@mojaloop/central-services-health": "7.0.0",
     "@mojaloop/central-services-metrics": "5.2.0",
-    "@mojaloop/central-services-shared": "7.5.0",
+    "@mojaloop/central-services-shared": "7.5.1",
     "@mojaloop/central-services-stream": "7.4.2",
     "@now-ims/hapi-now-auth": "2.0.0",
     "blipp": "4.0.0",

--- a/src/domain/participants/participants.js
+++ b/src/domain/participants/participants.js
@@ -72,9 +72,14 @@ const getParticipantsByTypeAndID = async (headers, params, method, query) => {
     }
   } catch (err) {
     Logger.error(err)
-    await participant.sendErrorToParticipant(headers[Enums.Http.Headers.FSPIOP.SOURCE], Enums.EndPoints.FspEndpointTypes.FSPIOP_CALLBACK_URL_PARTICIPANT_PUT_ERROR,
-      ErrorHandler.Factory.reformatFSPIOPError(err, ErrorHandler.Enums.FSPIOPErrorCodes.ADD_PARTY_INFO_ERROR).toApiErrorObject(), headers, params)
-    throw err
+    try {
+      await participant.sendErrorToParticipant(headers[Enums.Http.Headers.FSPIOP.SOURCE], Enums.EndPoints.FspEndpointTypes.FSPIOP_CALLBACK_URL_PARTICIPANT_PUT_ERROR,
+        ErrorHandler.Factory.reformatFSPIOPError(err, ErrorHandler.Enums.FSPIOPErrorCodes.ADD_PARTY_INFO_ERROR).toApiErrorObject(), headers, params)
+    } catch (exc) {
+      // We can't do anything else here- we _must_ handle all errors _within_ this function because
+      // we've already sent a sync response- we cannot throw.
+      Logger.error(exc)
+    }
   }
 }
 
@@ -146,9 +151,14 @@ const postParticipants = async (headers, method, params, payload) => {
     Logger.info('postParticipants::end')
   } catch (err) {
     Logger.error(err)
-    await participant.sendErrorToParticipant(headers[Enums.Http.Headers.FSPIOP.SOURCE], Enums.EndPoints.FspEndpointTypes.FSPIOP_CALLBACK_URL_PARTICIPANT_PUT_ERROR,
-      ErrorHandler.Factory.reformatFSPIOPError(err, ErrorHandler.Enums.FSPIOPErrorCodes.ADD_PARTY_INFO_ERROR).toApiErrorObject(), headers, params)
-    throw err
+    try {
+      await participant.sendErrorToParticipant(headers[Enums.Http.Headers.FSPIOP.SOURCE], Enums.EndPoints.FspEndpointTypes.FSPIOP_CALLBACK_URL_PARTICIPANT_PUT_ERROR,
+        ErrorHandler.Factory.reformatFSPIOPError(err, ErrorHandler.Enums.FSPIOPErrorCodes.ADD_PARTY_INFO_ERROR).toApiErrorObject(), headers, params)
+    } catch (exc) {
+      // We can't do anything else here- we _must_ handle all errors _within_ this function because
+      // we've already sent a sync response- we cannot throw.
+      Logger.error(exc)
+    }
   }
 }
 
@@ -239,7 +249,14 @@ const postParticipantsBatch = async (headers, method, requestPayload) => {
     }
   } catch (err) {
     Logger.error(err)
-    throw ErrorHandler.Factory.reformatFSPIOPError(err)
+    try {
+      await participant.sendErrorToParticipant(headers[Enums.Http.Headers.FSPIOP.SOURCE], Enums.EndPoints.FspEndpointTypes.FSPIOP_CALLBACK_URL_PARTICIPANT_BATCH_PUT_ERROR,
+        ErrorHandler.Factory.reformatFSPIOPError(err).toApiErrorObject(), headers, params)
+    } catch (exc) {
+      // We can't do anything else here- we _must_ handle all errors _within_ this function because
+      // we've already sent a sync response- we cannot throw.
+      Logger.error(exc)
+    }
   }
 }
 

--- a/src/domain/parties/parties.js
+++ b/src/domain/parties/parties.js
@@ -69,7 +69,14 @@ const getPartiesByTypeAndID = async (headers, params, method, query) => {
     }
   } catch (err) {
     Logger.error(err)
-    throw ErrorHandler.Factory.reformatFSPIOPError(err)
+    try {
+      await participant.sendErrorToParticipant(headers[Enums.Http.Headers.FSPIOP.SOURCE], Enums.EndPoints.FspEndpointTypes.FSPIOP_CALLBACK_URL_PARTIES_PUT_ERROR,
+        ErrorHandler.Factory.reformatFSPIOPError(err).toApiErrorObject(), headers, params)
+    } catch (exc) {
+      // We can't do anything else here- we _must_ handle all errors _within_ this function because
+      // we've already sent a sync response- we cannot throw.
+      Logger.error(exc)
+    }
   }
 }
 
@@ -109,7 +116,14 @@ const putPartiesByTypeAndID = async (headers, params, method, payload, dataUri) 
     }
   } catch (err) {
     Logger.error(err)
-    throw ErrorHandler.Factory.reformatFSPIOPError(err)
+    try {
+      await participant.sendErrorToParticipant(headers[Enums.Http.Headers.FSPIOP.SOURCE], Enums.EndPoints.FspEndpointTypes.FSPIOP_CALLBACK_URL_PARTIES_PUT_ERROR,
+        ErrorHandler.Factory.reformatFSPIOPError(err).toApiErrorObject(), headers, params)
+    } catch (exc) {
+      // We can't do anything else here- we _must_ handle all errors _within_ this function because
+      // we've already sent a sync response- we cannot throw.
+      Logger.error(exc)
+    }
   }
 }
 
@@ -135,7 +149,14 @@ const putPartiesErrorByTypeAndID = async (headers, params, payload, dataUri) => 
     }
   } catch (err) {
     Logger.error(err)
-    throw ErrorHandler.Factory.reformatFSPIOPError(err)
+    try {
+      await participant.sendErrorToParticipant(headers[Enums.Http.Headers.FSPIOP.SOURCE], Enums.EndPoints.FspEndpointTypes.FSPIOP_CALLBACK_URL_PARTIES_PUT_ERROR,
+        ErrorHandler.Factory.reformatFSPIOPError(err).toApiErrorObject(), headers, params)
+    } catch (exc) {
+      // We can't do anything else here- we _must_ handle all errors _within_ this function because
+      // we've already sent a sync response- we cannot throw.
+      Logger.error(exc)
+    }
   }
 }
 

--- a/src/handlers/participants.js
+++ b/src/handlers/participants.js
@@ -40,12 +40,9 @@ module.exports = {
    * responses: 202, 400, 401, 403, 404, 405, 406, 501, 503
    */
   post: function (req, h) {
-    try {
-      participants.postParticipantsBatch(req.headers, req.method, req.payload)
-    } catch (err) {
-      Logger.error(`ERROR - : ${err.stack}`)
-      throw ErrorHandler.Factory.reformatFSPIOPError(err)
-    }
+    // Here we call an async function- but as we send an immediate sync response, _all_ errors
+    // _must_ be handled by postParticipantsBatch.
+    participants.postParticipantsBatch(req.headers, req.method, req.payload)
     return h.response().code(200)
   }
 }

--- a/src/handlers/parties/{Type}/{ID}.js
+++ b/src/handlers/parties/{Type}/{ID}.js
@@ -39,11 +39,9 @@ module.exports = {
    * responses: 202, 400, 401, 403, 404, 405, 406, 501, 503
    */
   get: function (req, h) {
-    try {
-      parties.getPartiesByTypeAndID(req.headers, req.params, req.method, req.query)
-    } catch (err) {
-      throw ErrorHandler.Factory.reformatFSPIOPError(err)
-    }
+    // Here we call an async function- but as we send an immediate sync response, _all_ errors
+    // _must_ be handled by getPartiesByTypeAndID.
+    parties.getPartiesByTypeAndID(req.headers, req.params, req.method, req.query)
     return h.response().code(202)
   },
 
@@ -55,11 +53,9 @@ module.exports = {
    * responses: 200, 400, 401, 403, 404, 405, 406, 501, 503
    */
   put: function (req, h) {
-    try {
-      parties.putPartiesByTypeAndID(req.headers, req.params, req.method, req.payload, req.dataUri)
-    } catch (err) {
-      throw ErrorHandler.Factory.reformatFSPIOPError(err)
-    }
+    // Here we call an async function- but as we send an immediate sync response, _all_ errors
+    // _must_ be handled by getPartiesByTypeAndID.
+    parties.putPartiesByTypeAndID(req.headers, req.params, req.method, req.payload, req.dataUri)
     return h.response().code(200)
   }
 }

--- a/src/models/oracle/facade.js
+++ b/src/models/oracle/facade.js
@@ -107,7 +107,7 @@ exports.oracleRequest = async (headers, method, params = {}, query = {}, payload
     if (
       err.name === 'FSPIOPError' &&
       err.apiErrorCode.code === ErrorHandler.Enums.FSPIOPErrorCodes.DESTINATION_COMMUNICATION_ERROR.code &&
-      err.extensions.some(ext => (ext.key === 'status' && ext.value === 400))
+      err.extensions.some(ext => (ext.key === 'status' && ext.value === Enums.Http.ReturnCodes.BADREQUEST.CODE))
     ) {
       throw ErrorHandler.Factory.createFSPIOPError(ErrorHandler.Enums.FSPIOPErrorCodes.PARTY_NOT_FOUND)
     }

--- a/test/unit/handlers/participants/{Type}/{ID}.test.js
+++ b/test/unit/handlers/participants/{Type}/{ID}.test.js
@@ -28,11 +28,16 @@ const Sinon = require('sinon')
 const Mockgen = require('../../../../util/mockgen.js')
 const Db = require('../../../../../src/lib/db')
 const Logger = require('@mojaloop/central-services-shared').Logger
+const oracleEndpoint = require('../../../../../src/models/oracle')
+const participant = require('../../../../../src/models/participantEndpoint/facade')
 const participants = require('../../../../../src/domain/participants')
 const requestLogger = require('../../../../../src/lib/requestLogger')
 const Helper = require('../../../../util/helper')
 const initServer = require('../../../../../src/server').initialize
 const getPort = require('get-port')
+const ErrorHandler = require('@mojaloop/central-services-error-handling')
+const requestUtil = require('@mojaloop/central-services-shared').Util.Request
+const Enums = require('@mojaloop/central-services-shared').Enum
 
 let server
 let sandbox
@@ -50,7 +55,7 @@ Test.after(async () => {
   sandbox.restore()
 })
 
-Test('test getParticipantsByTypeAndID endpoint', async test => {
+Test.serial('test getParticipantsByTypeAndID endpoint', async test => {
   try {
     const requests = new Promise((resolve, reject) => {
       Mockgen().requests({
@@ -86,6 +91,64 @@ Test('test getParticipantsByTypeAndID endpoint', async test => {
     const response = await server.inject(options)
     test.is(response.statusCode, 202, 'Ok response status')
     participants.getParticipantsByTypeAndID.restore()
+  } catch (e) {
+    Logger.error(e)
+    test.fail()
+  }
+})
+
+Test.serial('test getParticipantsByTypeAndID endpoint sends async 3200 to /error for invalid party ID', async test => {
+  try {
+    const requests = new Promise((resolve, reject) => {
+      Mockgen().requests({
+        path: '/participants/{Type}/{ID}',
+        operation: 'get'
+      }, function (error, mock) {
+        return error ? reject(error) : resolve(mock)
+      })
+    })
+
+    const mock = await requests
+    test.pass(mock)
+    test.pass(mock.request)
+    const options = {
+      method: 'get',
+      url: mock.request.path,
+      headers: Helper.defaultSwitchHeaders
+    }
+    if (mock.request.body) {
+      // Send the request body
+      options.payload = mock.request.body
+    } else if (mock.request.formData) {
+      // Send the request form data
+      options.payload = mock.request.formData
+      // Set the Content-Type as application/x-www-form-urlencoded
+      options.headers = Helper.defaultSwitchHeaders || {}
+    }
+    // If headers are present, set the headers.
+    if (mock.request.headers && mock.request.headers.length > 0) {
+      options.headers = Helper.defaultSwitchHeaders
+    }
+
+    const badRequestError = ErrorHandler.Factory.createFSPIOPError(
+      ErrorHandler.Enums.FSPIOPErrorCodes.DESTINATION_COMMUNICATION_ERROR,
+      'Failed to send HTTP request to host',
+      {},
+      {},
+      [ { key: 'status', value: 400 } ]
+    )
+    const stubs = [
+      sandbox.stub(participant, 'sendErrorToParticipant').returns({}),
+      sandbox.stub(participant, 'validateParticipant').returns(true),
+      sandbox.stub(oracleEndpoint, 'getOracleEndpointByType').returns(['whatever']),
+      sandbox.stub(requestUtil, 'sendRequest').throws(badRequestError)
+    ]
+    const response = await server.inject(options)
+    const errorCallStub = stubs[0]
+    test.is(errorCallStub.args[0][2].errorInformation.errorCode, '3204')
+    test.is(errorCallStub.args[0][1], Enums.EndPoints.FspEndpointTypes.FSPIOP_CALLBACK_URL_PARTICIPANT_PUT_ERROR)
+    test.is(response.statusCode, 202, 'Ok response status')
+    stubs.forEach(s => s.restore())
   } catch (e) {
     Logger.error(e)
     test.fail()


### PR DESCRIPTION
- Bumped package version
- Bumped central services error handling and shared dependencies
- Because we send an immediate sync 202 to the requester, all errors are now handled in the domain. Otherwise, these result in an unhandled error in an async handler (and we don't do anything with them).
- Specifically handling a 400 from an oracle request to return an async error to the requester.
- Some tests of the oracle 400 functionality.