### PR TITLE
Bugfix/#979 Dependency conflict central-services-shared and central-services-stream

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1130,27 +1130,6 @@
         }
       }
     },
-    "@mojaloop/central-services-stream": {
-      "version": "8.1.1",
-      "resolved": "https://registry.npmjs.org/@mojaloop/central-services-stream/-/central-services-stream-8.1.1.tgz",
-      "integrity": "sha512-hmhBgiqHhQP8XEcHTRoVHWWwdHlv7FSz56U99ieoXNmK/V1Aqfdgo2IXokxOPlCyalwgteq+PpYlioyBje7YfA==",
-      "requires": {
-        "@mojaloop/central-services-error-handling": "7.5.0",
-        "@mojaloop/central-services-logger": "8.1.1",
-        "async": "3.1.0",
-        "debug": "4.1.1",
-        "events": "3.0.0",
-        "node-rdkafka": "2.7.1",
-        "raw-body": "2.4.1"
-      },
-      "dependencies": {
-        "async": {
-          "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/async/-/async-3.1.0.tgz",
-          "integrity": "sha512-4vx/aaY6j/j3Lw3fbCHNWP0pPaTCew3F6F3hYyl/tHs/ndmV1q7NW9T5yuJ2XAGwdQrP+6Wu20x06U4APo/iQQ=="
-        }
-      }
-    },
     "@mojaloop/event-sdk": {
       "version": "8.1.0",
       "resolved": "https://registry.npmjs.org/@mojaloop/event-sdk/-/event-sdk-8.1.0.tgz",
@@ -2055,14 +2034,6 @@
       "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.0.0.tgz",
       "integrity": "sha512-Phlt0plgpIIBOGTT/ehfFnbNlfsDEiqmzE2KRXoX1bLIlir4X/MR+zSyBEkL05ffWgnRSf/DXv+WrUAVr93/ow==",
       "dev": true
-    },
-    "bindings": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
-      "integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
-      "requires": {
-        "file-uri-to-path": "1.0.0"
-      }
     },
     "bintrees": {
       "version": "1.0.1",
@@ -4519,11 +4490,6 @@
       "requires": {
         "flat-cache": "^2.0.1"
       }
-    },
-    "file-uri-to-path": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
-      "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw=="
     },
     "fill-keys": {
       "version": "1.0.2",
@@ -7729,15 +7695,6 @@
         "encoding": "^0.1.11",
         "json-parse-better-errors": "^1.0.0",
         "safe-buffer": "^5.1.1"
-      }
-    },
-    "node-rdkafka": {
-      "version": "2.7.1",
-      "resolved": "https://registry.npmjs.org/node-rdkafka/-/node-rdkafka-2.7.1.tgz",
-      "integrity": "sha512-LrPTNtAoENJedyvYDI/AhBieq+aaFD+ImEIFAxJzL1HAYDZdCwe+TjivSK6N4YLXtxlbXVA1i43DK04VOWebeA==",
-      "requires": {
-        "bindings": "^1.3.1",
-        "nan": "^2.14.0"
       }
     },
     "normalize-package-data": {

--- a/package.json
+++ b/package.json
@@ -74,7 +74,6 @@
     "@mojaloop/central-services-logger": "8.1.1",
     "@mojaloop/central-services-metrics": "5.2.0",
     "@mojaloop/central-services-shared": "8.1.5",
-    "@mojaloop/central-services-stream": "8.1.1",
     "@now-ims/hapi-now-auth": "2.0.0",
     "blipp": "4.0.1",
     "commander": "3.0.2",

--- a/src/domain/parties/parties.js
+++ b/src/domain/parties/parties.js
@@ -31,7 +31,7 @@ const Enums = require('@mojaloop/central-services-shared').Enum
 const participant = require('../../models/participantEndpoint/facade')
 const ErrorHandler = require('@mojaloop/central-services-error-handling')
 const oracle = require('../../models/oracle/facade')
-const decodePayload = require('@mojaloop/central-services-stream').Kafka.Protocol.decodePayload
+const decodePayload = require('@mojaloop/central-services-shared').Util.StreamingProtocol.decodePayload
 
 /**
  * @function getPartiesByTypeAndID


### PR DESCRIPTION
Related issue: https://github.com/mojaloop/project/issues/979

This change:
 - Removes `@mojaloop/central-services-stream` dependency and uses the `decodePayload` function in `@mojaloop/central-services-shared` instead.