### PR TITLE
Feature/check for 404 [3201 --> 1001]

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "account-lookup-service",
-  "version": "9.3.1",
+  "version": "9.3.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -3019,9 +3019,9 @@
       },
       "dependencies": {
         "acorn": {
-          "version": "6.4.0",
-          "resolved": "https://registry.npmjs.org/acorn/-/acorn-6.4.0.tgz",
-          "integrity": "sha512-gac8OEcQ2Li1dxIEWGZzsp2BitJxwkwcOm0zHAJLcPJaVvm58FRnk6RkuLRpU1EujipU2ZFODv2P9DLMfnV8mw==",
+          "version": "6.4.1",
+          "resolved": "https://registry.npmjs.org/acorn/-/acorn-6.4.1.tgz",
+          "integrity": "sha512-ZVA9k326Nwrj3Cj9jlh3wGFutC2ZornPNARZwsNYqQYgN0EsV2d53w5RN/co65Ohn4sUAUtb1rSUAOD6XN9idA==",
           "dev": true
         }
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -3003,9 +3003,9 @@
       "dev": true
     },
     "acorn": {
-      "version": "7.1.0",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.1.0.tgz",
-      "integrity": "sha512-kL5CuoXA/dgxlBbVrflsflzQ3PAas7RYZB52NOm/6839iVYJgKMJ3cQJD+t2i5+qFa8h3MDpEOJiS64E8JLnSQ==",
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.1.1.tgz",
+      "integrity": "sha512-add7dgA5ppRPxCFJoAGfMDi7PIBXq1RtGo7BhbLaxwrXPOmw8gq48Y9ozT01hUKy9byMjlR20EJhu5zlkErEkg==",
       "dev": true
     },
     "acorn-globals": {
@@ -10733,9 +10733,9 @@
       }
     },
     "kind-of": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
-      "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA=="
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
+      "integrity": "sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw=="
     },
     "klaw": {
       "version": "3.0.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "account-lookup-service",
   "description": "Account Lookup Service is used to validate Party and Participant lookups",
-  "version": "9.3.1",
+  "version": "9.3.2",
   "license": "Apache-2.0",
   "author": "ModusBox",
   "contributors": [

--- a/src/models/oracle/facade.js
+++ b/src/models/oracle/facade.js
@@ -73,6 +73,8 @@ exports.oracleRequest = async (headers, method, params = {}, query = {}, payload
     Logger.error(err)
     // If the error was a 400 from the Oracle, we'll modify the error to generate a response to the
     // initiator of the request.
+    // Added error 404 to cover a special case of the Mowali implementation
+    // which uses mojaloop/als-oracle-pathfinder and currently returns 404.
     if (
       err.name === 'FSPIOPError' &&
       err.apiErrorCode.code === ErrorHandler.Enums.FSPIOPErrorCodes.DESTINATION_COMMUNICATION_ERROR.code &&

--- a/src/models/oracle/facade.js
+++ b/src/models/oracle/facade.js
@@ -76,7 +76,7 @@ exports.oracleRequest = async (headers, method, params = {}, query = {}, payload
     if (
       err.name === 'FSPIOPError' &&
       err.apiErrorCode.code === ErrorHandler.Enums.FSPIOPErrorCodes.DESTINATION_COMMUNICATION_ERROR.code &&
-      err.extensions.some(ext => (ext.key === 'status' && ext.value === Enums.Http.ReturnCodes.BADREQUEST.CODE))
+      err.extensions.some(ext => (ext.key === 'status' && (ext.value === Enums.Http.ReturnCodes.BADREQUEST.CODE || ext.value === Enums.Http.ReturnCodes.NOTFOUND.CODE)))
     ) {
       throw ErrorHandler.Factory.createFSPIOPError(ErrorHandler.Enums.FSPIOPErrorCodes.PARTY_NOT_FOUND)
     }

--- a/test/unit/handlers/participants/{Type}/{ID}.test.js
+++ b/test/unit/handlers/participants/{Type}/{ID}.test.js
@@ -79,7 +79,7 @@ describe('/participants/{Type}/{ID}', () => {
       participants.getParticipantsByTypeAndID.restore()
     })
 
-    it('getParticipantsByTypeAndID sends an async 3200 for invalid party id', async () => {
+    it('getParticipantsByTypeAndID sends an async 3200 for invalid party id on response with status 400', async () => {
       // Arrange
       const mock = await Helper.generateMockRequest('/participants/{Type}/{ID}', 'get')
       const options = {
@@ -94,6 +94,38 @@ describe('/participants/{Type}/{ID}', () => {
         {},
         {},
         [{ key: 'status', value: 400 }]
+      )
+      const stubs = [
+        sandbox.stub(participant, 'sendErrorToParticipant').returns({}),
+        sandbox.stub(participant, 'validateParticipant').returns(true),
+        sandbox.stub(oracleEndpoint, 'getOracleEndpointByType').returns(['whatever']),
+        sandbox.stub(requestUtil, 'sendRequest').throws(badRequestError)
+      ]
+      const response = await server.inject(options)
+      const errorCallStub = stubs[0]
+
+      // Assert
+      expect(errorCallStub.args[0][2].errorInformation.errorCode).toBe('3204')
+      expect(errorCallStub.args[0][1]).toBe(Enums.EndPoints.FspEndpointTypes.FSPIOP_CALLBACK_URL_PARTICIPANT_PUT_ERROR)
+      expect(response.statusCode).toBe(202)
+      stubs.forEach(s => s.restore())
+    })
+
+    it('getParticipantsByTypeAndID sends an async 3200 for invalid party id on response with status 404', async () => {
+      // Arrange
+      const mock = await Helper.generateMockRequest('/participants/{Type}/{ID}', 'get')
+      const options = {
+        method: 'get',
+        url: mock.request.path,
+        headers: Helper.defaultSwitchHeaders
+      }
+
+      const badRequestError = ErrorHandler.Factory.createFSPIOPError(
+        ErrorHandler.Enums.FSPIOPErrorCodes.DESTINATION_COMMUNICATION_ERROR,
+        'Failed to send HTTP request to host',
+        {},
+        {},
+        [{ key: 'status', value: 404 }]
       )
       const stubs = [
         sandbox.stub(participant, 'sendErrorToParticipant').returns({}),

--- a/test/unit/handlers/participants/{Type}/{ID}.test.js
+++ b/test/unit/handlers/participants/{Type}/{ID}.test.js
@@ -111,6 +111,8 @@ describe('/participants/{Type}/{ID}', () => {
       stubs.forEach(s => s.restore())
     })
 
+    // Added error 404 to cover a special case of the Mowali implementation
+    // which uses mojaloop/als-oracle-pathfinder and currently returns 404.
     it('getParticipantsByTypeAndID sends an async 3200 for invalid party id on response with status 404', async () => {
       // Arrange
       const mock = await Helper.generateMockRequest('/participants/{Type}/{ID}', 'get')

--- a/test/unit/handlers/participants/{Type}/{ID}/{SubId}.test.js
+++ b/test/unit/handlers/participants/{Type}/{ID}/{SubId}.test.js
@@ -107,6 +107,8 @@ describe('/participants/{Type}/{ID}/{SubId}', () => {
       stubs.forEach(s => s.restore())
     })
 
+    // Added error 404 to cover a special case of the Mowali implementation
+    // which uses mojaloop/als-oracle-pathfinder and currently returns 404.
     it('getParticipantsByTypeAndID sends an async 3200 for invalid party id on response with status 404', async () => {
       // Arrange
       const mock = await Helper.generateMockRequest('/participants/{Type}/{ID}/{SubId}', 'get')

--- a/test/unit/handlers/parties/{Type}/{ID}.test.js
+++ b/test/unit/handlers/parties/{Type}/{ID}.test.js
@@ -108,6 +108,8 @@ describe('/parties', () => {
     stubs.forEach(s => s.restore())
   })
 
+  // Added error 404 to cover a special case of the Mowali implementation
+  // which uses mojaloop/als-oracle-pathfinder and currently returns 404.
   it('getPartiesByTypeAndID endpoint sends async 3200 to /error for invalid party ID on response with status 404', async () => {
     // Arrange
     const mock = await Helper.generateMockRequest('/parties/{Type}/{ID}', 'get')

--- a/test/unit/handlers/parties/{Type}/{ID}.test.js
+++ b/test/unit/handlers/parties/{Type}/{ID}.test.js
@@ -74,7 +74,7 @@ describe('/parties', () => {
     parties.getPartiesByTypeAndID.restore()
   })
 
-  it('getPartiesByTypeAndID endpoint sends async 3200 to /error for invalid party ID', async () => {
+  it('getPartiesByTypeAndID endpoint sends async 3200 to /error for invalid party ID on response with status 400', async () => {
     // Arrange
     const mock = await Helper.generateMockRequest('/parties/{Type}/{ID}', 'get')
     const options = {
@@ -89,6 +89,40 @@ describe('/parties', () => {
       {},
       {},
       [{ key: 'status', value: 400 }]
+    )
+    const stubs = [
+      sandbox.stub(participant, 'sendErrorToParticipant').returns({}),
+      sandbox.stub(participant, 'validateParticipant').returns(true),
+      sandbox.stub(oracleEndpoint, 'getOracleEndpointByType').returns(['whatever']),
+      sandbox.stub(requestUtil, 'sendRequest').throws(badRequestError)
+    ]
+
+    // Act
+    const response = await server.inject(options)
+
+    // Assert
+    const errorCallStub = stubs[0]
+    expect(errorCallStub.args[0][2].errorInformation.errorCode).toBe('3204')
+    expect(errorCallStub.args[0][1]).toBe(Enums.EndPoints.FspEndpointTypes.FSPIOP_CALLBACK_URL_PARTIES_PUT_ERROR)
+    expect(response.statusCode).toBe(202)
+    stubs.forEach(s => s.restore())
+  })
+
+  it('getPartiesByTypeAndID endpoint sends async 3200 to /error for invalid party ID on response with status 404', async () => {
+    // Arrange
+    const mock = await Helper.generateMockRequest('/parties/{Type}/{ID}', 'get')
+    const options = {
+      method: 'get',
+      url: mock.request.path,
+      headers: Helper.defaultStandardHeaders('parties')
+    }
+
+    const badRequestError = ErrorHandler.Factory.createFSPIOPError(
+      ErrorHandler.Enums.FSPIOPErrorCodes.DESTINATION_COMMUNICATION_ERROR,
+      'Failed to send HTTP request to host',
+      {},
+      {},
+      [{ key: 'status', value: 404 }]
     )
     const stubs = [
       sandbox.stub(participant, 'sendErrorToParticipant').returns({}),

--- a/test/unit/handlers/parties/{Type}/{ID}/{SubId}.test.js
+++ b/test/unit/handlers/parties/{Type}/{ID}/{SubId}.test.js
@@ -105,6 +105,8 @@ describe('/parties/{Type}/{ID}/{SubId}', () => {
     stubs.forEach(s => s.restore())
   })
 
+  // Added error 404 to cover a special case of the Mowali implementation
+  // which uses mojaloop/als-oracle-pathfinder and currently returns 404.
   it('getPartiesByTypeAndID endpoint sends async 3200 to /error for invalid party ID with status 404', async () => {
     // Arrange
     const mock = await Helper.generateMockRequest('/parties/{Type}/{ID}/{SubId}', 'get')

--- a/test/unit/handlers/parties/{Type}/{ID}/{SubId}.test.js
+++ b/test/unit/handlers/parties/{Type}/{ID}/{SubId}.test.js
@@ -71,7 +71,7 @@ describe('/parties/{Type}/{ID}/{SubId}', () => {
     parties.getPartiesByTypeAndID.restore()
   })
 
-  it('getPartiesByTypeAndID endpoint sends async 3200 to /error for invalid party ID', async () => {
+  it('getPartiesByTypeAndID endpoint sends async 3200 to /error for invalid party ID on response with status 400', async () => {
     // Arrange
     const mock = await Helper.generateMockRequest('/parties/{Type}/{ID}/{SubId}', 'get')
     const options = {
@@ -86,6 +86,40 @@ describe('/parties/{Type}/{ID}/{SubId}', () => {
       {},
       {},
       [{ key: 'status', value: 400 }]
+    )
+    const stubs = [
+      sandbox.stub(participant, 'sendErrorToParticipant').returns({}),
+      sandbox.stub(participant, 'validateParticipant').returns(true),
+      sandbox.stub(oracleEndpoint, 'getOracleEndpointByType').returns(['whatever']),
+      sandbox.stub(requestUtil, 'sendRequest').throws(badRequestError)
+    ]
+
+    // Act
+    const response = await server.inject(options)
+
+    // Assert
+    const errorCallStub = stubs[0]
+    expect(errorCallStub.args[0][2].errorInformation.errorCode).toBe('3204')
+    expect(errorCallStub.args[0][1]).toBe(Enums.EndPoints.FspEndpointTypes.FSPIOP_CALLBACK_URL_PARTIES_SUB_ID_PUT_ERROR)
+    expect(response.statusCode).toBe(202)
+    stubs.forEach(s => s.restore())
+  })
+
+  it('getPartiesByTypeAndID endpoint sends async 3200 to /error for invalid party ID with status 404', async () => {
+    // Arrange
+    const mock = await Helper.generateMockRequest('/parties/{Type}/{ID}/{SubId}', 'get')
+    const options = {
+      method: 'get',
+      url: mock.request.path,
+      headers: Helper.defaultStandardHeaders('parties')
+    }
+
+    const badRequestError = ErrorHandler.Factory.createFSPIOPError(
+      ErrorHandler.Enums.FSPIOPErrorCodes.DESTINATION_COMMUNICATION_ERROR,
+      'Failed to send HTTP request to host',
+      {},
+      {},
+      [{ key: 'status', value: 404 }]
     )
     const stubs = [
       sandbox.stub(participant, 'sendErrorToParticipant').returns({}),


### PR DESCRIPTION
Added an additional check as it makes more sense to check for 404 since the returned error code is `PARTY_NOT_FOUND`. Kept the check of 400 for backwards compatibility.

This covers a special case of the Mowali implementation which uses https://github.com/mojaloop/als-oracle-pathfinder and currently returns 404 when the target is not found in the DB.