### PR TITLE
Add custom mojaloop policy for evaluating anchore-cli scans

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,6 +9,7 @@ version: 2.1
 orbs:
   anchore: anchore/anchore-engine@1.6.0
   deploy-kube: mojaloop/deployment@0.1.6
+  slack: circleci/slack@3.4.2
 
 ##
 # defaults
@@ -50,7 +51,7 @@ executors:
   default-docker:
     working_directory: /home/circleci/project
     docker: 
-      - image: node:12.16.0-alpine
+      - image: node:12.16.1-alpine
 
   default-machine:
     machine:
@@ -237,6 +238,13 @@ jobs:
       - setup_remote_docker
       - checkout
       - run:
+          name: Install docker dependencies for anchore
+          command: |
+            apk add --update py-pip docker python-dev libffi-dev openssl-dev gcc libc-dev make jq npm
+      - run:
+          name: Install general dependencies
+          command: *defaults_Dependencies
+      - run:
           name: Install AWS CLI dependencies
           command: *defaults_awsCliDependencies
       - attach_workspace:
@@ -244,40 +252,39 @@ jobs:
       - run:
           name: Load the pre-built docker image from workspace
           command: docker load -i /tmp/docker-image.tar
+      - run:
+          name: Download the mojaloop/ci-config repo
+          command: |
+            git clone https://github.com/mojaloop/ci-config /tmp/ci-config
+            # Generate the mojaloop anchore-policy
+            cd /tmp/ci-config/container-scanning && ./mojaloop-policy-generator.js /tmp/mojaloop-policy.json
+      - run:
+          name: Pull base image locally
+          command: |
+            docker pull node:12.16.1-alpine
+      # Analyze the base and derived image
+      # Note: It seems images are scanned in parallel, so preloading the base image result doesn't give us any real performance gain
       - anchore/analyze_local_image:
-          dockerfile_path: ./Dockerfile
-          image_name: ${DOCKER_ORG}/${CIRCLE_PROJECT_REPONAME}:${CIRCLE_TAG}
-          # Anchore bug: if policy_failure is `true`, reports don't get written - we manually check for failures below
+          # Force the older version, version 0.7.0 was just published, and is broken
+          anchore_version: v0.6.1
+          image_name: "docker.io/node:12.16.1-alpine $DOCKER_ORG/$CIRCLE_PROJECT_REPONAME:$CIRCLE_TAG"
           policy_failure: false
           timeout: '500'
-      - run:
-          name: Evaluate Failures.
-          command: |
-            if [[ ! $(which jq) ]]; then
-              (set +o pipefail; apk add jq || apt-get install -y jq || yum install -y jq)
-            fi
-            if [[ $(ls anchore-reports/*content-os*.json 2> /dev/null) ]]; then
-              printf "\n%s\n" "The following OS packages are installed:"
-              jq '[.content | sort_by(.package) | .[] | {package: .package, version: .version}]' anchore-reports/*content-os*.json
-            fi
-            if [[ $(ls anchore-reports/*vuln*.json 2> /dev/null) ]]; then
-              printf "\n%s\n" "The following vulnerabilities were found:"
-              jq '[.vulnerabilities | group_by(.package) | .[] | {package: .[0].package, vuln: [.[].vuln]}]' anchore-reports/*vuln*.json
-            fi
+          # Note: if the generated policy is invalid, this will fallback to the default policy, which we don't want!
+          policy_bundle_file_path: /tmp/mojaloop-policy.json
       - run:
           name: Upload Anchore reports to s3
           command: |
             aws s3 cp anchore-reports ${AWS_S3_DIR_ANCHORE_REPORTS}/${CIRCLE_PROJECT_REPONAME}/ --recursive
             aws s3 rm ${AWS_S3_DIR_ANCHORE_REPORTS}/latest/ --recursive --exclude "*" --include "${CIRCLE_PROJECT_REPONAME}*"
             aws s3 cp anchore-reports ${AWS_S3_DIR_ANCHORE_REPORTS}/latest/ --recursive
-
-            # TODO: Enable this when we want to increase the strictness of our security policies
-            # failCount=$(cat anchore-reports/*policy*.json | grep 'fail' | wc -l)
-            # echo "FailCount is: ${failCount}"
-            # if [ $failCount -gt 0 ]; then
-            #   printf "Failed with a policy failure count of: ${failCount}"
-            #   exit 1
-            # fi
+      - run:
+          name: Evaluate failures
+          command: /tmp/ci-config/container-scanning/anchore-result-diff.js anchore-reports/node_12.16.1-alpine-policy.json anchore-reports/${CIRCLE_PROJECT_REPONAME}*-policy.json
+      - slack/status:
+          fail_only: true
+          webhook: "$SLACK_WEBHOOK_ANNOUNCEMENT"
+          failure_message: 'Anchore Image Scan failed  for: \`"${DOCKER_ORG}/${CIRCLE_PROJECT_REPONAME}:${CIRCLE_TAG}"\`'
       - store_artifacts:
           path: anchore-reports
 
@@ -304,14 +311,9 @@ jobs:
             docker push $DOCKER_ORG/$CIRCLE_PROJECT_REPONAME:$CIRCLE_TAG
             echo "Publishing $DOCKER_ORG/$CIRCLE_PROJECT_REPONAME:$RELEASE_TAG"
             docker push $DOCKER_ORG/$CIRCLE_PROJECT_REPONAME:$RELEASE_TAG
-      - run:
-          name: Slack announcement for tag releases
-          command: |
-            curl -X POST \
-              $SLACK_WEBHOOK_ANNOUNCEMENT \
-              -H 'Content-type: application/json' \
-              -H 'cache-control: no-cache' \
-              -d "{\"text\": \"*${CIRCLE_PROJECT_REPONAME}* - Release \`${CIRCLE_TAG}\`: https://github.com/mojaloop/${CIRCLE_PROJECT_REPONAME}/releases/tag/${CIRCLE_TAG}\"}"
+      - slack/status:
+          webhook: "$SLACK_WEBHOOK_ANNOUNCEMENT"
+          success_message: '*"${CIRCLE_PROJECT_REPONAME}"* - Release \`"${CIRCLE_TAG}"\` \nhttps://github.com/mojaloop/"${CIRCLE_PROJECT_REPONAME}"/releases/tag/"${CIRCLE_TAG}"'
 
   deploy:
     executor: deploy-kube/helm-kube
@@ -323,6 +325,10 @@ jobs:
             --set .account-lookup-service.account-lookup-service.containers.api.image.tag=$CIRCLE_TAG \
             --set .account-lookup-service.account-lookup-service.containers.admin.image.repository=$DOCKER_ORG/$CIRCLE_PROJECT_REPONAME \
             --set .account-lookup-service.account-lookup-service.containers.admin.image.tag=$CIRCLE_TAG
+      - slack/status:
+          fail_only: true
+          webhook: "$SLACK_WEBHOOK_ANNOUNCEMENT"
+          failure_message: 'Deployment failed for: \`"${DOCKER_ORG}/${CIRCLE_PROJECT_REPONAME}:${CIRCLE_TAG}"\`'
 
 ##
 # Workflows

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,5 @@
-FROM node:12.16.0-alpine AS builder
+FROM node:12.16.1-alpine AS builder
+USER root
 
 WORKDIR /opt/account-lookup-service
 
@@ -15,16 +16,19 @@ COPY migrations /opt/account-lookup-service/migrations
 COPY seeds /opt/account-lookup-service/seeds
 COPY src /opt/account-lookup-service/src
 
-FROM node:12.16.0-alpine
-
+FROM node:12.16.1-alpine
 WORKDIR /opt/account-lookup-service
-
-COPY --from=builder /opt/account-lookup-service .
-RUN npm prune --production
 
 # Create empty log file & link stdout to the application log file
 RUN mkdir ./logs && touch ./logs/combined.log
 RUN ln -sf /dev/stdout ./logs/combined.log
+
+# Create a non-root user: ml-user
+RUN adduser -D ml-user 
+USER ml-user
+
+COPY --chown=ml-user --from=builder /opt/account-lookup-service .
+RUN npm prune --production
 
 EXPOSE 4002
 EXPOSE 4001

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 [![Git Commit](https://img.shields.io/github/last-commit/mojaloop/account-lookup-service.svg?style=flat)](https://github.com/mojaloop/account-lookup-service/commits/master)
 [![Git Releases](https://img.shields.io/github/release/mojaloop/account-lookup-service.svg?style=flat)](https://github.com/mojaloop/account-lookup-service/releases)
 [![Docker pulls](https://img.shields.io/docker/pulls/mojaloop/account-lookup-service.svg?style=flat)](https://hub.docker.com/r/mojaloop/account-lookup-service)
-[![CircleCI](https://circleci.com/gh/mojaloop/account-lookup-service.svg?style=svg)](https://circleci.com/gh/mojaloop/account-lookup-service)
+[![CircleCI](https://circleci.com/gh/mojaloop/account-lookup-service.svg?style=svg)](https://app.circleci.com/pipelines/github/mojaloop/account-lookup-service)
 
 
 ## Documentation
@@ -121,7 +121,7 @@ docker-compose -f docker-compose.yml -f docker-compose.integration.yml rm -f
 
 ## Auditing Dependencies
 
-We use `npm-audit-resolver` along with `npm audit` to check dependencies for vulnerabilities, and keep track of resolved dependencies with an `audit-resolv.json` file.
+We use `npm-audit-resolver` along with `npm audit` to check dependencies for vulnerabilities, and keep track of resolved dependencies with an `audit-resolve.json` file.
 
 To start a new resolution process, run:
 ```bash
@@ -134,6 +134,18 @@ npm run audit:check
 ```
 
 And commit the changed `audit-resolve.json` to ensure that CircleCI will build correctly.
+
+## Container Scans
+
+As part of our CI/CD process, we use anchore-cli to scan our built docker container for vulnerabilities upon release.
+
+If you find your release builds are failing, refer to the [container scanning](https://github.com/mojaloop/ci-config#container-scanning) in our shared Mojaloop CI config repo. There is a good chance you simply need to update the `mojaloop-policy-generator.js` file and re-run the circleci workflow.
+
+For more information on anchore and anchore-cli, refer to:
+- [Anchore CLI](https://github.com/anchore/anchore-cli)
+- [Circle Orb Registry](https://circleci.com/orbs/registry/orb/anchore/anchore-engine)
+
+
 
 ## Additional Notes: 
 

--- a/audit-resolve.json
+++ b/audit-resolve.json
@@ -66,48 +66,48 @@
     },
     "1179|@mojaloop/central-services-health>@mojaloop/central-services-shared>@mojaloop/event-sdk>grpc>node-pre-gyp>mkdirp>minimist": {
       "decision": "ignore",
-      "madeAt": 1585828827407,
-      "expiresAt": 1586433315594
+      "madeAt": 1586768330517,
+      "expiresAt": 1589360322367
     },
     "1179|@mojaloop/central-services-shared>@mojaloop/event-sdk>grpc>node-pre-gyp>mkdirp>minimist": {
       "decision": "ignore",
-      "madeAt": 1585828827407,
-      "expiresAt": 1586433315594
+      "madeAt": 1586768330517,
+      "expiresAt": 1589360322367
     },
     "1179|@mojaloop/event-sdk>grpc>node-pre-gyp>mkdirp>minimist": {
       "decision": "ignore",
-      "madeAt": 1585828827407,
-      "expiresAt": 1586433315594
+      "madeAt": 1586768330517,
+      "expiresAt": 1589360322367
     },
     "1179|@mojaloop/central-services-health>@mojaloop/central-services-shared>@mojaloop/event-sdk>grpc>node-pre-gyp>tar>mkdirp>minimist": {
       "decision": "ignore",
-      "madeAt": 1585828827407,
-      "expiresAt": 1586433315594
+      "madeAt": 1586768330517,
+      "expiresAt": 1589360322367
     },
     "1179|@mojaloop/central-services-shared>@mojaloop/event-sdk>grpc>node-pre-gyp>tar>mkdirp>minimist": {
       "decision": "ignore",
-      "madeAt": 1585828827407,
-      "expiresAt": 1586433315594
+      "madeAt": 1586768330517,
+      "expiresAt": 1589360322367
     },
     "1179|@mojaloop/event-sdk>grpc>node-pre-gyp>tar>mkdirp>minimist": {
       "decision": "ignore",
-      "madeAt": 1585828827407,
-      "expiresAt": 1586433315594
+      "madeAt": 1586768330517,
+      "expiresAt": 1589360322367
     },
     "1179|@mojaloop/central-services-health>@mojaloop/central-services-shared>@mojaloop/event-sdk>grpc>node-pre-gyp>rc>minimist": {
       "decision": "ignore",
-      "madeAt": 1585828827407,
-      "expiresAt": 1586433315594
+      "madeAt": 1586768330517,
+      "expiresAt": 1589360322367
     },
     "1179|@mojaloop/central-services-shared>@mojaloop/event-sdk>grpc>node-pre-gyp>rc>minimist": {
       "decision": "ignore",
-      "madeAt": 1585828827407,
-      "expiresAt": 1586433315594
+      "madeAt": 1586768330517,
+      "expiresAt": 1589360322367
     },
     "1179|@mojaloop/event-sdk>grpc>node-pre-gyp>rc>minimist": {
       "decision": "ignore",
-      "madeAt": 1585828827407,
-      "expiresAt": 1586433315594
+      "madeAt": 1586768330517,
+      "expiresAt": 1589360322367
     }
   },
   "rules": {},

--- a/docker-compose.integration.yml
+++ b/docker-compose.integration.yml
@@ -9,6 +9,7 @@ services:
         - mojaloop/account-lookup-service
         - account-lookup-service
     container_name: als_account-lookup-service-int
+    user: root
     networks:
       - als-mojaloop-net
     command:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,6 +9,7 @@ services:
     build:
       context: .
     container_name: als_account-lookup-service
+    user: root
     command:
       - "sh"
       - "-c"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "account-lookup-service",
   "description": "Account Lookup Service is used to validate Party and Participant lookups.",
-  "version": "9.5.1",
+  "version": "9.5.2",
   "license": "Apache-2.0",
   "author": "ModusBox",
   "contributors": [


### PR DESCRIPTION
Adds a custom policy for anchore-cli to evaluate the container security during a release

Also:
- adds a default `ml-user` to the dockerfile
- adds some more slack notifications to the announcements channel for different failures
- updates the readme with a new circleci link and info about container scanning


Closes: #1223