### PR TITLE
fix(#2358): firstname, middlename and lastname regex not supporting myanmar script unicode strings

### DIFF
--- a/audit-resolve.json
+++ b/audit-resolve.json
@@ -12,8 +12,8 @@
     },
     "1675|@mojaloop/central-services-shared>shins>sanitize-html": {
       "decision": "ignore",
-      "madeAt": 1626939586100,
-      "expiresAt": 1627544372805
+      "madeAt": 1628676843672,
+      "expiresAt": 1629281621500
     },
     "1673|@mojaloop/central-services-shared>openapi-backend>lodash": {
       "decision": "fix",
@@ -33,8 +33,8 @@
     },
     "1676|@mojaloop/central-services-shared>shins>sanitize-html": {
       "decision": "ignore",
-      "madeAt": 1626939586100,
-      "expiresAt": 1627544372805
+      "madeAt": 1628676843672,
+      "expiresAt": 1629281621500
     },
     "1500|00unidentified>widdershins>yargs>yargs-parser": {
       "decision": "ignore",
@@ -54,6 +54,14 @@
     "1766|00unidentified>widdershins>urijs": {
       "decision": "fix",
       "madeAt": 1626888065939
+    },
+    "1770|@mojaloop/event-sdk>grpc>@mapbox/node-pre-gyp>tar": {
+      "decision": "fix",
+      "madeAt": 1628676837889
+    },
+    "1771|@mojaloop/event-sdk>grpc>@mapbox/node-pre-gyp>tar": {
+      "decision": "fix",
+      "madeAt": 1628676837889
     }
   },
   "rules": {},

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "account-lookup-service",
-  "version": "11.7.0",
+  "version": "11.7.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1786,9 +1786,9 @@
           }
         },
         "chalk": {
-          "version": "4.1.1",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.1.tgz",
-          "integrity": "sha512-diHzdDKxcU+bAsUboHLPEDQiw0qEe0qd7SYUn3HgcFlWgbDcfLGswOHYeGrHKzG9z6UYf01d9VFMfZxPM1xZSg==",
+          "version": "4.1.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+          "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
           "dev": true,
           "requires": {
             "ansi-styles": "^4.1.0",
@@ -2416,9 +2416,9 @@
       }
     },
     "@types/jest": {
-      "version": "26.0.24",
-      "resolved": "https://registry.npmjs.org/@types/jest/-/jest-26.0.24.tgz",
-      "integrity": "sha512-E/X5Vib8BWqZNRlDxj9vYXhsDwPYbPINqKF9BsnSoon4RQ0D9moEuLD8txgyypFLH7J4+Lho9Nr/c8H0Fi+17w==",
+      "version": "27.0.0",
+      "resolved": "https://registry.npmjs.org/@types/jest/-/jest-27.0.0.tgz",
+      "integrity": "sha512-IlpQZVpxufe+3qPaAqEoSPHVSxnJh1cf0BqqWHJeKiAUbwnHdmNzjP3ZCWSZSTbmAGXQPNk9QmM3Bif0pR54rg==",
       "dev": true,
       "requires": {
         "jest-diff": "^26.0.0",
@@ -3871,9 +3871,9 @@
       }
     },
     "commander": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-8.0.0.tgz",
-      "integrity": "sha512-Xvf85aAtu6v22+E5hfVoLHqyul/jyxh91zvqk/ioJTQuJR7Z78n7H558vMPKanPSRgIEeZemT92I2g9Y8LPbSQ=="
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-8.1.0.tgz",
+      "integrity": "sha512-mf45ldcuHSYShkplHHGKWb4TrmwQadxOn7v4WuhDJy0ZVoY5JFajaRDKD0PNe5qXzBX0rhovjTnP6Kz9LETcuA=="
     },
     "commondir": {
       "version": "1.0.1",
@@ -5108,9 +5108,9 @@
       }
     },
     "eslint": {
-      "version": "7.31.0",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-7.31.0.tgz",
-      "integrity": "sha512-vafgJpSh2ia8tnTkNUkwxGmnumgckLh5aAbLa1xRmIn9+owi8qBNGKL+B881kNKNTy7FFqTEkpNkUvmw0n6PkA==",
+      "version": "7.32.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-7.32.0.tgz",
+      "integrity": "sha512-VHZ8gX+EDfz+97jGcgyGCyRia/dPOd6Xh9yPv8Bl1+SoaIwD+a/vlrOmGRUyOYu7MwUhc7CxqeaDZU13S4+EpA==",
       "dev": true,
       "requires": {
         "@babel/code-frame": "7.12.11",
@@ -5201,9 +5201,9 @@
           }
         },
         "chalk": {
-          "version": "4.1.1",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.1.tgz",
-          "integrity": "sha512-diHzdDKxcU+bAsUboHLPEDQiw0qEe0qd7SYUn3HgcFlWgbDcfLGswOHYeGrHKzG9z6UYf01d9VFMfZxPM1xZSg==",
+          "version": "4.1.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+          "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
           "dev": true,
           "requires": {
             "ansi-styles": "^4.1.0",
@@ -6089,9 +6089,9 @@
       }
     },
     "flatted": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.2.1.tgz",
-      "integrity": "sha512-OMQjaErSFHmHqZe+PSidH5n8j3O0F2DdnVh8JB4j4eUQ2k6KvB0qGfrKIhapvez5JerBbmWkaLYUYWISaESoXg==",
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.2.2.tgz",
+      "integrity": "sha512-JaTY/wtrcSyvXJl4IMFHPKyFur1sE9AUqc0QnhOaJ0CxHtAoIV8pYDzeEfAaNEtGkOfq4gr3LBFmdXW5mOQFnA==",
       "dev": true
     },
     "fn.name": {
@@ -8171,9 +8171,9 @@
           }
         },
         "chalk": {
-          "version": "4.1.1",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.1.tgz",
-          "integrity": "sha512-diHzdDKxcU+bAsUboHLPEDQiw0qEe0qd7SYUn3HgcFlWgbDcfLGswOHYeGrHKzG9z6UYf01d9VFMfZxPM1xZSg==",
+          "version": "4.1.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+          "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
           "dev": true,
           "requires": {
             "ansi-styles": "^4.1.0",
@@ -10180,9 +10180,9 @@
       "dev": true
     },
     "joi": {
-      "version": "17.4.1",
-      "resolved": "https://registry.npmjs.org/joi/-/joi-17.4.1.tgz",
-      "integrity": "sha512-gDPOwQ5sr+BUxXuPDGrC1pSNcVR/yGGcTI0aCnjYxZEa3za60K/iCQ+OFIkEHWZGVCUcUlXlFKvMmrlmxrG6UQ==",
+      "version": "17.4.2",
+      "resolved": "https://registry.npmjs.org/joi/-/joi-17.4.2.tgz",
+      "integrity": "sha512-Lm56PP+n0+Z2A2rfRvsfWVDXGEWjXxatPopkQ8qQ5mxCEhwHG+Ettgg5o98FFaxilOxozoa14cFhrE/hOzh/Nw==",
       "requires": {
         "@hapi/hoek": "^9.0.0",
         "@hapi/topo": "^5.0.0",
@@ -13940,13 +13940,13 @@
       }
     },
     "sinon": {
-      "version": "11.1.1",
-      "resolved": "https://registry.npmjs.org/sinon/-/sinon-11.1.1.tgz",
-      "integrity": "sha512-ZSSmlkSyhUWbkF01Z9tEbxZLF/5tRC9eojCdFh33gtQaP7ITQVaMWQHGuFM7Cuf/KEfihuh1tTl3/ABju3AQMg==",
+      "version": "11.1.2",
+      "resolved": "https://registry.npmjs.org/sinon/-/sinon-11.1.2.tgz",
+      "integrity": "sha512-59237HChms4kg7/sXhiRcUzdSkKuydDeTiamT/jesUVHshBgL8XAmhgFo0GfK6RruMDM/iRSij1EybmMog9cJw==",
       "dev": true,
       "requires": {
         "@sinonjs/commons": "^1.8.3",
-        "@sinonjs/fake-timers": "^7.1.0",
+        "@sinonjs/fake-timers": "^7.1.2",
         "@sinonjs/samsam": "^6.0.2",
         "diff": "^5.0.0",
         "nise": "^5.1.0",
@@ -15208,9 +15208,9 @@
       "dev": true
     },
     "tar": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/tar/-/tar-6.1.0.tgz",
-      "integrity": "sha512-DUCttfhsnLCjwoDoFcI+B2iJgYa93vBnDUATYEeRx6sntCTdN01VnqsIuTlALXla/LWooNg0yEGeB+Y8WdFxGA==",
+      "version": "6.1.7",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-6.1.7.tgz",
+      "integrity": "sha512-PBoRkOJU0X3lejJ8GaRCsobjXTgFofRDSPdSUhRSdlwJfifRlQBwGXitDItdGFu0/h0XDMCkig0RN1iT7DBxhA==",
       "requires": {
         "chownr": "^2.0.0",
         "fs-minipass": "^2.0.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "account-lookup-service",
   "description": "Account Lookup Service is used to validate Party and Participant lookups.",
-  "version": "11.7.0",
+  "version": "11.7.1",
   "license": "Apache-2.0",
   "author": "ModusBox",
   "contributors": [

--- a/package.json
+++ b/package.json
@@ -88,9 +88,9 @@
     "ajv": "8.6.2",
     "ajv-keywords": "5.0.0",
     "blipp": "4.0.2",
-    "commander": "8.0.0",
+    "commander": "8.1.0",
     "hapi-auth-bearer-token": "8.0.0",
-    "joi": "17.4.1",
+    "joi": "17.4.2",
     "knex": "0.95.7",
     "mustache": "4.2.0",
     "mysql": "2.18.1",
@@ -100,9 +100,9 @@
     "uuid4": "2.0.2"
   },
   "devDependencies": {
-    "@types/jest": "26.0.24",
+    "@types/jest": "27.0.0",
     "docdash": "1.2.0",
-    "eslint": "7.31.0",
+    "eslint": "7.32.0",
     "eslint-plugin-jest": "24.4.0",
     "get-port": "5.1.1",
     "jest": "27.0.6",
@@ -115,7 +115,7 @@
     "pre-commit": "1.2.2",
     "proxyquire": "2.1.3",
     "request-promise-native": "1.0.9",
-    "sinon": "11.1.1",
+    "sinon": "11.1.2",
     "standard": "16.0.3",
     "standard-version": "^9.3.1",
     "swagmock": "1.0.0"

--- a/src/interface/api-swagger.yaml
+++ b/src/interface/api-swagger.yaml
@@ -1230,7 +1230,7 @@ components:
       title: FirstName
       maxLength: 128
       minLength: 1
-      pattern: '^(?!\s*$)[\p{L}\p{Nd} .,''-]{1,128}$'
+      pattern: '^(?!\s*$)[\p{L}\p{gc=Mark}\p{digit}\p{gc=Connector_Punctuation}\p{Join_Control} .,''-]{1,128}$'
       type: string
       description: First name of the Party (Name Type).
     HealthServicesType:
@@ -1247,14 +1247,14 @@ components:
       title: LastName
       maxLength: 128
       minLength: 1
-      pattern: '^(?!\s*$)[\p{L}\p{Nd} .,''-]{1,128}$'
+      pattern: '^(?!\s*$)[\p{L}\p{gc=Mark}\p{digit}\p{gc=Connector_Punctuation}\p{Join_Control} .,''-]{1,128}$'
       type: string
       description: Last name of the Party (Name Type).
     MiddleName:
       title: MiddleName
       maxLength: 128
       minLength: 1
-      pattern: '^(?!\s*$)[\p{L}\p{Nd} .,''-]{1,128}$'
+      pattern: '^(?!\s*$)[\p{L}\p{gc=Mark}\p{digit}\p{gc=Connector_Punctuation}\p{Join_Control} .,''-]{1,128}$'
       type: string
       description: Middle name of the Party (Name Type).
     ParticipantsTypeIDSubIDPostRequest:

--- a/src/interface/thirdparty/api-swagger.yaml
+++ b/src/interface/thirdparty/api-swagger.yaml
@@ -1234,7 +1234,7 @@ components:
       title: FirstName
       maxLength: 128
       minLength: 1
-      pattern: '^(?!\s*$)[\p{L}\p{Nd} .,''-]{1,128}$'
+      pattern: '^(?!\s*$)[\p{L}\p{gc=Mark}\p{digit}\p{gc=Connector_Punctuation}\p{Join_Control} .,''-]{1,128}$'
       type: string
       description: First name of the Party (Name Type).
     HealthServicesType:
@@ -1251,14 +1251,14 @@ components:
       title: LastName
       maxLength: 128
       minLength: 1
-      pattern: '^(?!\s*$)[\p{L}\p{Nd} .,''-]{1,128}$'
+      pattern: '^(?!\s*$)[\p{L}\p{gc=Mark}\p{digit}\p{gc=Connector_Punctuation}\p{Join_Control} .,''-]{1,128}$'
       type: string
       description: Last name of the Party (Name Type).
     MiddleName:
       title: MiddleName
       maxLength: 128
       minLength: 1
-      pattern: '^(?!\s*$)[\p{L}\p{Nd} .,''-]{1,128}$'
+      pattern: '^(?!\s*$)[\p{L}\p{gc=Mark}\p{digit}\p{gc=Connector_Punctuation}\p{Join_Control} .,''-]{1,128}$'
       type: string
       description: Middle name of the Party (Name Type).
     ParticipantsTypeIDSubIDPostRequest:

--- a/test/unit/handlers/parties/{Type}/{ID}.test.js
+++ b/test/unit/handlers/parties/{Type}/{ID}.test.js
@@ -51,6 +51,10 @@ describe('/parties', () => {
     server = await initServer(await getPort())
   })
 
+  afterEach(async () => {
+    sandbox.restore()
+  })
+
   afterAll(async () => {
     await server.stop()
     sandbox.restore()
@@ -163,6 +167,27 @@ describe('/parties', () => {
     }
     options.payload.party.personalInfo.complexName.firstName = 'Justin'
     options.payload.party.personalInfo.complexName.middleName = 'middle'
+    options.payload.party.personalInfo.complexName.lastName = 'résumé'
+    sandbox.stub(parties, 'putPartiesByTypeAndID').returns({})
+
+    // Act
+    const response = await server.inject(options)
+
+    // Assert
+    expect(response.statusCode).toBe(200)
+  })
+
+  it('putPartiesByTypeAndID endpoint with additional asian (Myanmar) unicode characters', async () => {
+    // Arrange
+    const mock = await Helper.generateMockRequest('/parties/{Type}/{ID}', 'put')
+    const options = {
+      method: 'put',
+      url: mock.request.path,
+      headers: Helper.defaultStandardHeaders('parties'),
+      payload: mock.request.body
+    }
+    options.payload.party.personalInfo.complexName.firstName = 'Justin'
+    options.payload.party.personalInfo.complexName.middleName = 'ကောင်းထက်စံ'
     options.payload.party.personalInfo.complexName.lastName = 'résumé'
     sandbox.stub(parties, 'putPartiesByTypeAndID').returns({})
 


### PR DESCRIPTION
- Updated regex to match [\w](https://unicode.org/reports/tr18/#word) based on mappings to the [ECMAScript](https://262.ecma-international.org/9.0/#sec-runtime-semantics-unicodematchproperty-p) regex specification.
- Added unit test for putPartiesByTypeAndID endpoint with additional asian (Myanmar) unicode characters added to middleName
- Bump to patch version
- Updated dependencies to the latest version
- Fixed audit-resolve issues:

```text
--------------------------------------------------
 tar needs your attention.

[ high ] Arbitrary File Creation/Overwrite due to insufficient absolute path sanitization
 vulnerable versions <3.2.2 || >=4.0.0 <4.4.14 || >=5.0.0 <5.0.6 || >=6.0.0 <6.1.1 found in:
 - dependencies: @mojaloop/event-sdk>grpc>@mapbox/node-pre-gyp>tar
[ high ] Arbitrary File Creation/Overwrite via insufficient symlink protection due to directory cache poisoning
 vulnerable versions <3.2.3 || >=4.0.0 <4.4.15 || >=5.0.0 <5.0.7 || >=6.0.0 <6.1.2 found in:
 - dependencies: @mojaloop/event-sdk>grpc>@mapbox/node-pre-gyp>tar
```
> Outcome: Fix applied

```text
--------------------------------------------------
 sanitize-html needs your attention.

[ moderate ] Improper Input Validation
 vulnerable versions <2.3.1 found in:
 - dependencies: @mojaloop/central-services-shared>shins>sanitize-html
[ moderate ] Improper Input Validation
 vulnerable versions <2.3.2 found in:
 - dependencies: @mojaloop/central-services-shared>shins>sanitize-html
```
> Outcome: Ignored for 1 week
> Impact: Minimal as the dependencies are used for the Developer Documentation end-point
