### PR TITLE
chore: dependency and vulnerability updates pi26

### DIFF
--- a/audit-ci.jsonc
+++ b/audit-ci.jsonc
@@ -4,8 +4,6 @@
   // Only use one of ["low": true, "moderate": true, "high": true, "critical": true]
   "moderate": true,
   "allowlist": [ // NOTE: Please add as much information as possible to any items added to the allowList
-    // Currently no fixes available for the following
-    "GHSA-2p57-rm9w-gvfp", // socks>ip
     // The following issues are related to central-services-shared upgrade skip
     // Issue to resolve this: https://github.com/mojaloop/project/issues/3260
     "GHSA-hjrf-2m68-5959",

--- a/audit-ci.jsonc
+++ b/audit-ci.jsonc
@@ -6,17 +6,7 @@
   "allowlist": [ // NOTE: Please add as much information as possible to any items added to the allowList
     // Currently no fixes available for the following
     "GHSA-2p57-rm9w-gvfp", // socks>ip
-    "GHSA-v88g-cgmw-v5xw",
-    "GHSA-phwq-j96m-2c2q",
-    "GHSA-282f-qqgm-c34q",
-    "GHSA-6vfc-qv3f-vr6c",
-    "GHSA-wc69-rhjr-hc9g",
-    "GHSA-g954-5hwp-pp24",
-    "GHSA-rjqq-98f6-6j3r",
-    "GHSA-mjxr-4v3x-q3m4",
     "GHSA-qgmg-gppg-76g5",
-    "GHSA-p9pc-299p-vxgp",
-    "GHSA-8cf7-32gw-wr33",
     // The following issues are related to central-services-shared upgrade skip
     // Issue to resolve this: https://github.com/mojaloop/project/issues/3260
     "GHSA-hjrf-2m68-5959",
@@ -28,6 +18,12 @@
     "GHSA-rm97-x556-q36h", // https://github.com/advisories/GHSA-rm97-x556-q36h
     "GHSA-rv95-896h-c2vc", // https://github.com/advisories/GHSA-rv95-896h-c2vc
     "GHSA-3xgq-45jj-v275", // https://github.com/advisories/GHSA-3xgq-45jj-v275
-    "GHSA-rhx6-c78j-4q9w" // https://github.com/advisories/GHSA-rhx6-c78j-4q9w
+    "GHSA-rhx6-c78j-4q9w", // https://github.com/advisories/GHSA-rhx6-c78j-4q9w
+    "GHSA-mjxr-4v3x-q3m4", // https://github.com/advisories/GHSA-mjxr-4v3x-q3m4
+    "GHSA-phwq-j96m-2c2q", // https://github.com/advisories/GHSA-phwq-j96m-2c2q
+    "GHSA-rjqq-98f6-6j3r", // https://github.com/advisories/GHSA-rjqq-98f6-6j3r
+    "GHSA-mwcw-c2x4-8c55", // https://github.com/advisories/GHSA-mwcw-c2x4-8c55
+    // The following issues are related to @mojaloop/event-sdk upgrade skip
+    "GHSA-g954-5hwp-pp24" // https://github.com/advisories/GHSA-g954-5hwp-pp24
   ]
 }

--- a/audit-ci.jsonc
+++ b/audit-ci.jsonc
@@ -6,7 +6,6 @@
   "allowlist": [ // NOTE: Please add as much information as possible to any items added to the allowList
     // Currently no fixes available for the following
     "GHSA-2p57-rm9w-gvfp", // socks>ip
-    "GHSA-qgmg-gppg-76g5",
     // The following issues are related to central-services-shared upgrade skip
     // Issue to resolve this: https://github.com/mojaloop/project/issues/3260
     "GHSA-hjrf-2m68-5959",

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,9 +20,9 @@
         "@mojaloop/central-services-error-handling": "13.0.2",
         "@mojaloop/central-services-health": "15.0.0",
         "@mojaloop/central-services-logger": "11.5.1",
-        "@mojaloop/central-services-metrics": "12.4.1",
+        "@mojaloop/central-services-metrics": "12.4.2",
         "@mojaloop/central-services-shared": "18.7.1",
-        "@mojaloop/central-services-stream": "11.3.1",
+        "@mojaloop/central-services-stream": "11.4.1",
         "@mojaloop/database-lib": "11.0.6",
         "@mojaloop/event-sdk": "14.1.1",
         "@mojaloop/inter-scheme-proxy-cache-lib": "2.3.1",
@@ -32,7 +32,7 @@
         "ajv-keywords": "5.1.0",
         "blipp": "4.0.2",
         "commander": "12.1.0",
-        "cron": "3.3.0",
+        "cron": "3.3.1",
         "fast-safe-stringify": "^2.1.1",
         "hapi-auth-bearer-token": "8.0.0",
         "joi": "17.13.3",
@@ -55,7 +55,7 @@
         "jest": "29.7.0",
         "jest-junit": "16.0.0",
         "jsdoc": "4.0.4",
-        "nodemon": "3.1.7",
+        "nodemon": "3.1.9",
         "npm-check-updates": "17.1.11",
         "nyc": "17.1.0",
         "pre-commit": "1.2.2",
@@ -1875,9 +1875,9 @@
       }
     },
     "node_modules/@mojaloop/central-services-metrics": {
-      "version": "12.4.1",
-      "resolved": "https://registry.npmjs.org/@mojaloop/central-services-metrics/-/central-services-metrics-12.4.1.tgz",
-      "integrity": "sha512-KkbXfKDAxuy//v0q4cSQ52YSL7QGndiQXSK6cUBTywHViXSkeCMe+0bV8FLScgnLKRJTgLTDAbmXVWen5SoLMw==",
+      "version": "12.4.2",
+      "resolved": "https://registry.npmjs.org/@mojaloop/central-services-metrics/-/central-services-metrics-12.4.2.tgz",
+      "integrity": "sha512-0XFW9nBJNY70tya/DEYlGl12adfb/3cAWuHv88vF8JI+JQAIE/6ePyET1Wb3tMp0BUcjFF5b1XbbYcOF69wKZQ==",
       "dependencies": {
         "prom-client": "15.1.3"
       }
@@ -2009,11 +2009,11 @@
       }
     },
     "node_modules/@mojaloop/central-services-stream": {
-      "version": "11.3.1",
-      "resolved": "https://registry.npmjs.org/@mojaloop/central-services-stream/-/central-services-stream-11.3.1.tgz",
-      "integrity": "sha512-mSdWvEFJEjKkZdDs+e1yeZm/gFfXTqA+eVRIBmp8p67QJy36ZTaAvrvebGYKZ60MBN2syDrqL+DbQMJdoxHLEA==",
+      "version": "11.4.1",
+      "resolved": "https://registry.npmjs.org/@mojaloop/central-services-stream/-/central-services-stream-11.4.1.tgz",
+      "integrity": "sha512-LbnT/JAqliL8xWf/vCt5fJGIP8+o5Gcx265GPXbJPKSQrJ8UV5cUs1CIv0S/nYjrZuvfeEI3RQYuc93NF9qO3g==",
       "dependencies": {
-        "async": "3.2.5",
+        "async": "3.2.6",
         "async-exit-hook": "2.0.1",
         "events": "3.3.0",
         "node-rdkafka": "2.18.0"
@@ -2898,9 +2898,9 @@
       }
     },
     "node_modules/async": {
-      "version": "3.2.5",
-      "resolved": "https://registry.npmjs.org/async/-/async-3.2.5.tgz",
-      "integrity": "sha512-baNZyqaaLhyLVKm/DlvdW051MSgO6b8eVfIezl9E5PqWxFgzLm/wQntEW4zOytVburDEr0JlALEpdOFwvErLsg=="
+      "version": "3.2.6",
+      "resolved": "https://registry.npmjs.org/async/-/async-3.2.6.tgz",
+      "integrity": "sha512-htCUDlxyyCLMgaM3xXg0C0LW2xqfuQ6p05pCEIsXuyQ+a1koYKTuBMzRNwmybfLgvJDMd0r1LTn4+E0Ti6C2AA=="
     },
     "node_modules/async-exit-hook": {
       "version": "2.0.1",
@@ -4248,9 +4248,9 @@
       }
     },
     "node_modules/cron": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/cron/-/cron-3.3.0.tgz",
-      "integrity": "sha512-uwRMLudSn2vPPjg392dKOm3KoJRw/eOOFtcHbrmRJxCd/NDF3187JVnajTvHPIlam0UwhKUZWwVPd1V5vBlmsw==",
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/cron/-/cron-3.3.1.tgz",
+      "integrity": "sha512-KpvuzJEbeTMTfLsXhUuDfsFYr8s5roUlLKb4fa68GszWrA4783C7q6m9yj4vyc6neyD/V9e0YiADSX2c+yRDXg==",
       "dependencies": {
         "@types/luxon": "~3.4.0",
         "luxon": "~3.5.0"
@@ -9929,9 +9929,9 @@
       "dev": true
     },
     "node_modules/nodemon": {
-      "version": "3.1.7",
-      "resolved": "https://registry.npmjs.org/nodemon/-/nodemon-3.1.7.tgz",
-      "integrity": "sha512-hLj7fuMow6f0lbB0cD14Lz2xNjwsyruH251Pk4t/yIitCFJbmY1myuLlHm/q06aST4jg6EgAh74PIBBrRqpVAQ==",
+      "version": "3.1.9",
+      "resolved": "https://registry.npmjs.org/nodemon/-/nodemon-3.1.9.tgz",
+      "integrity": "sha512-hdr1oIb2p6ZSxu3PB2JWWYS7ZQ0qvaZsc3hK8DR8f02kRzc8rjYmxAIvdz+aYC+8F2IjNaB7HMcSDg8nQpJxyg==",
       "dev": true,
       "dependencies": {
         "chokidar": "^3.5.2",
@@ -14228,9 +14228,9 @@
       }
     },
     "node_modules/validator": {
-      "version": "10.11.0",
-      "resolved": "https://registry.npmjs.org/validator/-/validator-10.11.0.tgz",
-      "integrity": "sha512-X/p3UZerAIsbBfN/IwahhYaBbY68EN/UQBWHtsbXGT5bfrH/p4NQzUCG1kF/rtKaNpnJ7jAu6NGTdSNtyNIXMw==",
+      "version": "13.7.0",
+      "resolved": "https://registry.npmjs.org/validator/-/validator-13.7.0.tgz",
+      "integrity": "sha512-nYXQLCBkpJ8X6ltALua9dRrZDHVYxjJ1wgskNt1lH9fzGjs3tgojGSCBjmEPwkWS1y29+DrizMTW19Pr9uB2nw==",
       "dev": true,
       "engines": {
         "node": ">= 0.10"

--- a/package.json
+++ b/package.json
@@ -93,9 +93,9 @@
     "@mojaloop/central-services-error-handling": "13.0.2",
     "@mojaloop/central-services-health": "15.0.0",
     "@mojaloop/central-services-logger": "11.5.1",
-    "@mojaloop/central-services-metrics": "12.4.1",
+    "@mojaloop/central-services-metrics": "12.4.2",
     "@mojaloop/central-services-shared": "18.7.1",
-    "@mojaloop/central-services-stream": "11.3.1",
+    "@mojaloop/central-services-stream": "11.4.1",
     "@mojaloop/database-lib": "11.0.6",
     "@mojaloop/event-sdk": "14.1.1",
     "@mojaloop/inter-scheme-proxy-cache-lib": "2.3.1",
@@ -105,7 +105,7 @@
     "ajv-keywords": "5.1.0",
     "blipp": "4.0.2",
     "commander": "12.1.0",
-    "cron": "3.3.0",
+    "cron": "3.3.1",
     "fast-safe-stringify": "^2.1.1",
     "hapi-auth-bearer-token": "8.0.0",
     "joi": "17.13.3",
@@ -145,7 +145,8 @@
       "yargs-parser": "^21.1.1"
     },
     "jsonwebtoken": "9.0.0",
-    "jsonpointer": "5.0.0"
+    "jsonpointer": "5.0.0",
+    "validator": "13.7.0"
   },
   "devDependencies": {
     "@types/jest": "29.5.14",
@@ -159,7 +160,7 @@
     "jest": "29.7.0",
     "jest-junit": "16.0.0",
     "jsdoc": "4.0.4",
-    "nodemon": "3.1.7",
+    "nodemon": "3.1.9",
     "npm-check-updates": "17.1.11",
     "nyc": "17.1.0",
     "pre-commit": "1.2.2",


### PR DESCRIPTION
The following issues are related to central-services-shared and were kept/added to allowlist to be fixed at at that repo:
    "GHSA-hjrf-2m68-5959",
    "GHSA-qwph-4952-7xr6",
    "GHSA-4jv9-3563-23j3",
    "GHSA-h755-8qp9-cq85",
    "GHSA-f9xv-q969-pqx4",
    "GHSA-7fh5-64p2-3v2j",
    "GHSA-rm97-x556-q36h",
    "GHSA-rv95-896h-c2vc", 
    "GHSA-3xgq-45jj-v275", 
    "GHSA-rhx6-c78j-4q9w", 
    "GHSA-mjxr-4v3x-q3m4",
    "GHSA-phwq-j96m-2c2q",
    "GHSA-rjqq-98f6-6j3r", 
    "GHSA-mwcw-c2x4-8c55", 

The following issue is related to @mojaloop/event-sdk and was added to allowlist to be fixed at at that repo:
    "GHSA-g954-5hwp-pp24"